### PR TITLE
returning peerflix object from export function for better programmatic handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,4 +266,6 @@ module.exports = function(filename, opts, ready) {
 	peerflix.clearCache = function() {
 		if (fs.existsSync(peerflix.destination)) fs.unlinkSync(peerflix.destination);
 	};
+
+	return peerflix;
 }


### PR DESCRIPTION
for apps that want to integrate peerflix (instead of command line usage), we should be able to get access to the peerflix object after calling the export function.

specifically for calling the `.destroy()` method before starting another peerflix server
