### PR TITLE
Added functionality to list available files

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ var argv = optimist
 	.alias('c', 'connections').describe('c', 'max connected peers').default('c', os.cpus().length > 1 ? 100 : 30)
 	.alias('p', 'port').describe('p', 'change the http port').default('p', 8888)
 	.alias('i', 'index').describe('i', 'changed streamed file (index)')
+	.alias('l', 'list').describe('l', 'list available files with corresponding index')
 	.alias('t', 'subtitles').describe('t', 'load subtitles file')
 	.alias('q', 'quiet').describe('q', 'be quiet')
 	.alias('v', 'vlc').describe('v', 'autoplay in vlc*')
@@ -49,6 +50,18 @@ var noop = function() {};
 var ontorrent = function(torrent) {
 	var engine = peerflix(torrent, argv);
 	var hotswaps = 0;
+
+if (argv.list) {
+	var onready = function() {
+		engine.files.forEach(function(file, i, files) {
+			clivas.line('{3+bold:'+i+'} : {magenta:'+file.name+'}');
+		})
+		process.exit(0);
+	};
+	if (engine.torrent) onready();
+	else engine.on('ready', onready);
+	return;
+}
 
 	engine.on('hotswap', function() {
 		hotswaps++;

--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ var createServer = function(e, index) {
 module.exports = function(torrent, opts) {
 	if (!opts) opts = {};
 	var e = engine(torrent, opts);
-	e.server = createServer(e, opts.index);
+	if (!opts.list) {
+		e.server = createServer(e, opts.index);
+	};
 	return e;
 };


### PR DESCRIPTION
Not sure if I was missing something but I couldn't seem to find a way inside or outside of peerflix to find the index of files within a torrent and a lot of torrents did not seem to follow any sane order so just quickly added an extra command to list all available files so that you know which index to specify.

I imagine this is rarely necessary for movies but is obviously good for TV series. Thought you might enjoy.
