### PR TITLE
fixed error on finding the path of VLC in non-english Windows

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,7 +100,7 @@ if (argv.list) {
 			}
 
 			if (!!key) {
-				var vlcPath = key["(Default)"].value;
+				var vlcPath = ( key['(Default)'] || function(){for (var name in key) if (name[0] === '(') return key[name];}() ) .value;
 				VLC_ARGS = VLC_ARGS.split(' ');
 				VLC_ARGS.unshift(href);
 				if (argv.vlc) proc.execFile(vlcPath, VLC_ARGS);


### PR DESCRIPTION
Should fix #34
If the "(Default)" valuedoesn't exist, it searches for a value which name starts with a parenthesis.
