### PR TITLE
handle non-standard vlc location on osx

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,7 +141,7 @@ var ontorrent = function(torrent) {
 			}
 		} else {
 			if (argv.vlc) {
-				var vlc = proc.exec('vlc '+href+' '+VLC_ARGS+' || /Applications/VLC.app/Contents/MacOS/VLC '+href+' '+VLC_ARGS, function(error, stdout, stderror){
+				var vlc = proc.exec('vlc '+href+' '+VLC_ARGS+' || open -a VLC --args '+href+' '+VLC_ARGS, function(error, stdout, stderror){
 					if (error) {
 						process.exit(0);
 					}


### PR DESCRIPTION
by using open instead of hard-coding the path it will look for VLC in the `/Users/**/Applications/` path as well
