### PR TITLE
CORS support for peerflix server

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ var createServer = function(e, index) {
 	};
 
 	server.on('request', function(request, response) {
+
+		if(request.headers.origin) {
+			response.setHeader('Access-Control-Allow-Origin', request.headers.origin);
+		}
 		var u = url.parse(request.url);
 		var host = request.headers.host || 'localhost';
 


### PR DESCRIPTION
Added support for CORS.

Useful for streaming to Chromecast with subtitles (Docs say both stream and subtitles need to be on CORS enabled server for subtitles to work)
