### PR TITLE
Add option for host that external programs uses

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ var argv = rc('peerflix', {}, optimist
 	.alias('n', 'no-quit').describe('n', 'do not quit peerflix on vlc exit')
 	.alias('a', 'all').describe('a', 'select all files in the torrent')
 	.alias('r', 'remove').describe('r', 'remove files on exit')
+	.alias('u', 'host').describe('u', 'the host external programs should use for streaming')
 	.alias('e', 'peer').describe('e', 'add peer by ip:port')
 	.alias('x', 'peer-port').describe('x', 'set peer listening port')
 	.alias('d', 'not-on-top').describe('d', 'do not float video on top')
@@ -114,7 +115,8 @@ var ontorrent = function(torrent) {
 	})
 
 	engine.server.on('listening', function() {
-		var href = 'http://'+address()+':'+engine.server.address().port+'/';
+		var host = argv.u ? argv.u : address()
+		var href = 'http://'+host+':'+engine.server.address().port+'/';
 		var filename = engine.server.index.name.split('/').pop().replace(/\{|\}/g, '');
 		var filelength = engine.server.index.length;
 


### PR DESCRIPTION
This host is used to build up the url used for streaming that is sent to external programs.
