### PR TITLE
Add exit message

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,13 @@ var peerflix = require('./');
 var path = require('path');
 
 process.title = 'peerflix';
+process.on('SIGINT', function() {
+	// we're doing some heavy lifting so it can take some time to exit... let's
+	// better output a status message so the user knows we're working on it :)
+	clivas.line('');
+	clivas.line('{yellow:info} {green:peerflix is exiting...}');
+	process.exit();
+});
 
 var argv = rc('peerflix', {}, optimist
 	.usage('Usage: $0 magnet-link-or-torrent [options]')


### PR DESCRIPTION
When Node.js have been working hard (steaming torrent's apparently is hard) it can sometime take a while to exit. The user might not know this and thinks it will not exit. This PR will print a nice message to the user telling him that we got the request and are working on exiting...
