### PR TITLE
Pass options after '--' to video player

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,6 +74,16 @@ if (argv.t) {
 	MPV_EXEC += ' --sub-file=' + argv.t;
 }
 
+if (argv._.length > 1) {
+	var _args = argv._;
+	_args.shift();
+	var playerArgs = _args.join(' ');
+	VLC_ARGS += ' ' + playerArgs;
+	OMX_EXEC += ' ' + playerArgs;
+	MPLAYER_EXEC += ' ' + playerArgs;
+	MPV_EXEC += ' ' + playerArgs;
+}
+
 var noop = function() {};
 
 var ontorrent = function(torrent) {


### PR DESCRIPTION
All the options that are passed after `--` are directly passed as
command line arguments to the video player used. Fixes #124 

So for example this is possible to play the video fullscreen in vlc: 

```
peerflix <link> --vlc -- -f
```
