### PR TITLE
better syntax & on-download triggers  even with -q

### DIFF
--- a/app.js
+++ b/app.js
@@ -137,9 +137,13 @@ var ontorrent = function(torrent) {
 		engine.connect(peer);
 	})
 
-	if (argv['on-downloaded']) engine.on('uninterested', function() {
-		proc.exec(argv['on-downloaded'])
-	});
+	if (argv['on-downloaded']){
+		var downloaded = false;
+		engine.on('uninterested', function() {
+			if(!downloaded) proc.exec(argv['on-downloaded'])
+			downloaded = true;
+		});
+	}
 
 	engine.server.on('listening', function() {
 		var host = argv.hostname || address()


### PR DESCRIPTION
Very minor changes
- switched to `on-downloaded` & `on-listening` syntax, will improve readability if we end up with lots of events.
- moved code around so that `on-listening` gets the full href even with --all and on-downloaded gets triggered even if --quiet
