### PR TITLE
See output of external commands like `--omx` or `--on-listening`

### DIFF
--- a/app.js
+++ b/app.js
@@ -179,7 +179,7 @@ var ontorrent = function (torrent) {
   if (argv['on-downloaded']) {
     var downloaded = false
     engine.on('uninterested', function () {
-      if (!downloaded) proc.exec(argv['on-downloaded'])
+      if (!downloaded) spawn(argv['on-downloaded'])
       downloaded = true
     })
   }
@@ -295,7 +295,7 @@ var ontorrent = function (torrent) {
       browser.start()
     }
 
-    if (argv['on-listening']) proc.exec(argv['on-listening'] + ' ' + href)
+    if (argv['on-listening']) spawn(argv['on-listening'] + ' ' + href)
 
     if (argv.quiet) return console.log('server is listening on ' + href)
 

--- a/app.js
+++ b/app.js
@@ -104,6 +104,11 @@ if (argv._.length > 1) {
 
 var noop = function () {}
 
+var spawn = function(commandString) {
+  var parts = commandString.split(/\s+/g);
+  proc.spawn(parts[0], parts.slice(1), { stdio: 'inherit' })
+}
+
 var ontorrent = function (torrent) {
   if (argv['peer-port']) argv.peerPort = Number(argv['peer-port'])
 
@@ -264,7 +269,7 @@ var ontorrent = function (torrent) {
 
     if (argv.omx) {
       player = 'omx'
-      proc.exec(OMX_EXEC + ' ' + localHref)
+      spawn(OMX_EXEC + ' ' + localHref)
     }
     if (argv.mplayer) {
       player = 'mplayer'


### PR DESCRIPTION
Hey, thanks for peerflix which works incredibly well :)

I started to use it [on a tiny project](https://github.com/Leimi/katflix) and stumbled upon something when using `--omx` or `--on-listening`: those external commands' outputs were not visible.

I figured it could be useful to have the output of those commands directly in the cli, so I changed the `exec` call for the `omx`, `on-listening` and `on-downloaded` options and replaced it with `spawn`.

I did this mostly because when I want to use peerflix from a raspberry pi and omx, the omx keyboard shortcuts don't work with a simple `exec`.

What do you think?