### PR TITLE
Replaced read-torrent with parse-torrent. Info hashes are now supported.

### DIFF
--- a/app.js
+++ b/app.js
@@ -433,16 +433,10 @@ var ontorrent = function (torrent) {
   }
 }
 
-try {
-  try {
-    ontorrent(parsetorrent(filename))
-  } catch (err) {
-    parsetorrent.remote(filename, function (error, parsedtorrent) {
-      if (error) throw error
-      ontorrent(parsedtorrent)
-    })
+parsetorrent.remote(filename, function (err, parsedtorrent) {
+  if (err) {
+    console.error(err.message)
+    process.exit(1)
   }
-} catch (err) {
-  console.error(err.message)
-  process.exit(1)
-}
+  ontorrent(parsedtorrent)
+})

--- a/app.js
+++ b/app.js
@@ -435,6 +435,8 @@ var ontorrent = function (torrent) {
 
 if (/^magnet:/.test(filename)) {
   ontorrent(filename)
+} else if (filename.length === 40) {
+  ontorrent('magnet:?xt=urn:btih:' + filename)
 } else {
   // TODO: don't use read-torrent anymore as we don't really use the parsing part of it...
   readTorrent(filename, function (err, torrent, raw) {

--- a/app.js
+++ b/app.js
@@ -435,7 +435,7 @@ var ontorrent = function (torrent) {
 
 if (/^magnet:/.test(filename)) {
   ontorrent(filename)
-} else if (filename.length === 40) {
+} else if (/^([a-f0-9]){40}$/i.test(filename)) {
   ontorrent('magnet:?xt=urn:btih:' + filename)
 } else {
   // TODO: don't use read-torrent anymore as we don't really use the parsing part of it...

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "pump": "^0.3.1",
     "range-parser": "^1.0.0",
     "rc": "^0.4.0",
-    "read-torrent": "^1.1.0",
     "torrent-stream": "^0.20.0",
     "windows-no-runnable": "~0.0.6",
-    "xtend": "^4.0.0"
+    "xtend": "^4.0.0",
+    "parse-torrent": "^5.4.0"
   },
   "devDependencies": {
     "standard": "^2.2.3"


### PR DESCRIPTION
This adds support for calls like: `peerflix "ef330b39f4801d25b4245212e75a38634bfc856e" --vlc` for when you don't have a magnet or torrent link and you're too lazy to convert the hash to a magnet link yourself.