### PR TITLE
Providing file name in the URI to provide the file name to the media player.

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,9 +181,9 @@ var ontorrent = function (torrent) {
 
   engine.server.on('listening', function () {
     var host = argv.hostname || address()
-    var href = 'http://' + host + ':' + engine.server.address().port + '/'
-    var localHref = 'http://localhost:' + engine.server.address().port + '/'
     var filename = engine.server.index.name.split('/').pop().replace(/\{|\}/g, '')
+    var href = 'http://' + host + ':' + engine.server.address().port + '/' + filename
+    var localHref = 'http://localhost:' + engine.server.address().port + '/' + filename
     var filelength = engine.server.index.length
     var player = null
     var paused = false


### PR DESCRIPTION
Providing file name in the URI. This will provide the file name to the media player. This is useful to VLSub to look for subs using the file name.

Unfortunately due a bug that prevents to execute VLSub on files that are in a root folder peerflix will not be able to run yet.

I have also sent a fix to vlc project to fix this problem you can read more one the vlc mail list
https://mailman.videolan.org/pipermail/vlc-devel/2015-November/104998.html
