### PR TITLE
Fix for Windows where subtitles path should not be encoded for VLC

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,7 +81,7 @@ var enc = function (s) {
 }
 
 if (argv.t) {
-  VLC_ARGS += ' --sub-file=' + enc(argv.t)
+  VLC_ARGS += ' --sub-file=' + (process.platform === 'win32') ? argv.t : enc(argv.t)
   OMX_EXEC += ' --subtitles ' + enc(argv.t)
   MPLAYER_EXEC += ' -sub ' + enc(argv.t)
   SMPLAYER_EXEC += ' -sub ' + enc(argv.t)


### PR DESCRIPTION
Fix for Windows where subtitles path should not be encoded for VLC.

Previous to this fix, VLC would not load the subtitles due to "weird" characters.