### PR TITLE
Add option to open torrent's folder with shortcut CTRL+L

### DIFF
--- a/app.js
+++ b/app.js
@@ -320,7 +320,7 @@ var ontorrent = function (torrent) {
         if (key.name === 'c' && key.ctrl === true) return process.kill(process.pid, 'SIGINT')
         if (key.name === 'l' && key.ctrl === true) {
           var command = 'xdg-open'
-          if (process.platform === 'win32')  { command = 'explorer' }
+          if (process.platform === 'win32') { command = 'explorer' }
           if (process.platform === 'darwin') { command = 'open' }
 
           return proc.exec(command + ' ' + engine.path)

--- a/app.js
+++ b/app.js
@@ -318,6 +318,7 @@ var ontorrent = function (torrent) {
       process.stdin.on('keypress', function (ch, key) {
         if (!key) return
         if (key.name === 'c' && key.ctrl === true) return process.kill(process.pid, 'SIGINT')
+        if (key.name === 'l' && key.ctrl === true) return proc.exec('open ' + engine.path)
         if (key.name !== 'space') return
 
         if (player) return
@@ -372,8 +373,9 @@ var ontorrent = function (torrent) {
       clivas.line('{80:}')
 
       if (interactive) {
-        if (paused) clivas.line('{yellow:PAUSED} {green:Press SPACE to continue download}')
-        else clivas.line('{50+green:Press SPACE to pause download}')
+        var openLoc = ' or CTRL+L to open download location}'
+        if (paused) clivas.line('{yellow:PAUSED} {green:Press SPACE to continue download' + openLoc)
+        else clivas.line('{50+green:Press SPACE to pause download' + openLoc)
       }
 
       clivas.line('')

--- a/app.js
+++ b/app.js
@@ -318,7 +318,13 @@ var ontorrent = function (torrent) {
       process.stdin.on('keypress', function (ch, key) {
         if (!key) return
         if (key.name === 'c' && key.ctrl === true) return process.kill(process.pid, 'SIGINT')
-        if (key.name === 'l' && key.ctrl === true) return proc.exec('open ' + engine.path)
+        if (key.name === 'l' && key.ctrl === true) {
+          var command = 'xdg-open'
+          if (process.platform === 'win32')  { command = 'explorer' }
+          if (process.platform === 'darwin') { command = 'open' }
+
+          return proc.exec(command + ' ' + engine.path)
+        }
         if (key.name !== 'space') return
 
         if (player) return


### PR DESCRIPTION
I personally needed this option,the reason for this is while content is downloading I have to find it in `/tmp/torrent-stream/...` to be able to open it with a custom player (in my case `beamer`). Now all you need to do is hit CTRL+L to open that folder. 

MaxOSX, Ubuntu, Windows are supported and tested. Other OS will be opened with command `xdg-open` which should be supported on other UNIX distributions. 