### PR TITLE
Fix wrong VLC command generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -323,7 +323,7 @@ var ontorrent = function (torrent) {
             type: 'video'
           }
         }, function (err, result) {
-          if (err) throw err;
+          if (err) throw err
         })
       })
 

--- a/app.js
+++ b/app.js
@@ -81,7 +81,7 @@ var enc = function (s) {
 }
 
 if (argv.t) {
-  VLC_ARGS += ' --sub-file=' + (process.platform === 'win32') ? argv.t : enc(argv.t)
+  VLC_ARGS += ' --sub-file=' + ((process.platform === 'win32') ? argv.t : enc(argv.t))
   OMX_EXEC += ' --subtitles ' + enc(argv.t)
   MPLAYER_EXEC += ' -sub ' + enc(argv.t)
   SMPLAYER_EXEC += ' -sub ' + enc(argv.t)

--- a/app.js
+++ b/app.js
@@ -319,7 +319,7 @@ var ontorrent = function (torrent) {
           metadata: {
             title: filename,
             type: 'video',
-            subtitlesUrl: href + 'subtitles.srt'
+            subtitlesUrl: href + 'subtitles'
           }
         }, function (err, result) {
           if (err) throw err

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ var argv = rc('peerflix', {}, optimist
   .alias('q', 'quiet').describe('q', 'be quiet').boolean('v')
   .alias('v', 'vlc').describe('v', 'autoplay in vlc*').boolean('v')
   .alias('s', 'airplay').describe('s', 'autoplay via AirPlay').boolean('a')
+  .alias('u', 'dlna').describe('u', 'autoplay via DLNA').boolean('u')
   .alias('m', 'mplayer').describe('m', 'autoplay in mplayer*').boolean('m')
   .alias('g', 'smplayer').describe('g', 'autoplay in smplayer*').boolean('g')
   .describe('mpchc', 'autoplay in MPC-HC player*').boolean('boolean')
@@ -303,6 +304,32 @@ var ontorrent = function (torrent) {
         device.play(href, 0, noop)
       })
       browser.start()
+    }
+
+    if (argv.dlna) {
+      var Browser = require('nodecast-js')
+      var Client = require('upnp-mediarenderer-client')
+
+      var nodecast = new Browser()
+
+      nodecast.onDevice(function (device) {
+        device.onError(function (err) {
+          throw err
+        })
+
+        new Client(device.xml).load(href, {
+          autoplay: true,
+          // contentType: 'video/' + path.extname(filename).substring(1),
+          metadata: {
+            title: filename,
+            type: 'video'
+          }
+        }, function (err, result) {
+          if (err) throw err;
+        })
+      })
+
+      nodecast.start()
     }
 
     if (argv['on-listening']) proc.exec(argv['on-listening'] + ' ' + href)

--- a/app.js
+++ b/app.js
@@ -303,7 +303,6 @@ var ontorrent = function (torrent) {
         player.play(href)
       })
     }
-
     if (argv.dlna) {
       var Browser = require('nodecast-js')
       var Client = require('upnp-mediarenderer-client')
@@ -317,10 +316,10 @@ var ontorrent = function (torrent) {
 
         new Client(device.xml).load(href, {
           autoplay: true,
-          // contentType: 'video/' + path.extname(filename).substring(1),
           metadata: {
             title: filename,
-            type: 'video'
+            type: 'video',
+            subtitlesUrl: href + 'subtitles.srt'
           }
         }, function (err, result) {
           if (err) throw err

--- a/index.js
+++ b/index.js
@@ -135,6 +135,14 @@ var createServer = function (e, opts) {
       return
     }
 
+    if (opts.t && u.pathname === '/subtitles.srt') {
+      var subtitles = fs.readFileSync(opts.t, 'utf8')
+      response.setHeader('Content-Type', 'text/srt')
+      response.setHeader('Content-Length', Buffer.byteLength(subtitles))
+      response.end(subtitles)
+      return
+    }
+
     e.files.forEach(function (file, i) {
       if (u.pathname.slice(1) === file.name) u.pathname = '/' + i
     })
@@ -153,7 +161,9 @@ var createServer = function (e, opts) {
     response.setHeader('Accept-Ranges', 'bytes')
     response.setHeader('Content-Type', getType(file.name))
     response.setHeader('transferMode.dlna.org', 'Streaming')
-    response.setHeader('contentFeatures.dlna.org', 'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=017000 00000000000000000000000000')
+    response.setHeader('contentFeatures.dlna.org', 'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000')
+    response.setHeader('CaptionInfo.sec', 'http://' + host + '/subtitles.srt')
+
     if (!range) {
       response.setHeader('Content-Length', file.length)
       if (request.method === 'HEAD') return response.end()
@@ -174,6 +184,8 @@ var createServer = function (e, opts) {
 
   return server
 }
+
+
 
 module.exports = function (torrent, opts) {
   if (!opts) opts = {}

--- a/index.js
+++ b/index.js
@@ -135,9 +135,10 @@ var createServer = function (e, opts) {
       return
     }
 
-    if (opts.t && u.pathname === '/subtitles.srt') {
+    if (opts.t && u.pathname === '/subtitles') {
       var subtitles = fs.readFileSync(opts.t, 'utf8')
-      response.setHeader('Content-Type', 'text/srt')
+      var subs_mime = mime.lookup(opts.t)
+      response.setHeader('Content-Type', subs_mime)
       response.setHeader('Content-Length', Buffer.byteLength(subtitles))
       response.end(subtitles)
       return
@@ -158,11 +159,12 @@ var createServer = function (e, opts) {
     var file = e.files[i]
     var range = request.headers.range
     range = range && rangeParser(file.length, range)[0]
+
     response.setHeader('Accept-Ranges', 'bytes')
     response.setHeader('Content-Type', getType(file.name))
     response.setHeader('transferMode.dlna.org', 'Streaming')
     response.setHeader('contentFeatures.dlna.org', 'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000')
-    response.setHeader('CaptionInfo.sec', 'http://' + host + '/subtitles.srt')
+    if (opts.t) response.setHeader('CaptionInfo.sec', 'http://' + host + '/subtitles')
 
     if (!range) {
       response.setHeader('Content-Length', file.length)
@@ -184,7 +186,6 @@ var createServer = function (e, opts) {
 
   return server
 }
-
 
 
 module.exports = function (torrent, opts) {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "peerflix",
   "description": "Streaming torrent client for Node.js",
-  "version": "0.35.0",
+  "version": "0.35.0 - iovis9 fork",
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
-  "homepage": "https://github.com/mafintosh/peerflix",
+  "homepage": "https://github.com/iovis9/peerflix",
   "main": "index.js",
   "bugs": {
-    "url": "https://github.com/mafintosh/peerflix/issues"
+    "url": "https://github.com/iovis9/peerflix/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mafintosh/peerflix.git"
+    "url": "git://github.com/iovis9/peerflix.git"
   },
   "bin": {
     "peerflix": "./app.js"

--- a/package.json
+++ b/package.json
@@ -18,26 +18,26 @@
   },
   "dependencies": {
     "airplayer": "^2.0.0",
-    "clivas": "^0.1.4",
-    "inquirer": "^0.8.0",
+    "clivas": "^0.2.0",
+    "inquirer": "^1.0.3",
     "keypress": "^0.2.1",
     "mime": "^1.2.11",
-    "network-address": "0.0.5",
-    "nodecast-js": "^0.1.2",
+    "network-address": "^1.1.0",
+    "nodecast-js": "^1.0.3",
     "numeral": "^1.5.3",
     "open": "0.0.5",
     "optimist": "^0.6.1",
     "parse-torrent": "^5.4.0",
-    "pump": "^0.3.1",
-    "range-parser": "^1.0.0",
-    "rc": "^0.4.0",
-    "torrent-stream": "^1.0.1",
-    "upnp-mediarenderer-client": "^1.2.1",
+    "pump": "^1.0.1",
+    "range-parser": "^1.2.0",
+    "rc": "^1.1.6",
+    "torrent-stream": "^1.0.3",
+    "upnp-mediarenderer-client": "^1.2.3",
     "windows-no-runnable": "~0.0.6",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "standard": "^2.2.3"
+    "standard": "^7.1.2"
   },
   "optionalDependencies": {
     "airplayer": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "keypress": "^0.2.1",
     "mime": "^1.2.11",
     "network-address": "0.0.5",
+    "nodecast-js": "^0.1.2",
     "numeral": "^1.5.3",
     "open": "0.0.5",
     "optimist": "^0.6.1",
@@ -31,6 +32,7 @@
     "range-parser": "^1.0.0",
     "rc": "^0.4.0",
     "torrent-stream": "^1.0.1",
+    "upnp-mediarenderer-client": "^1.2.1",
     "windows-no-runnable": "~0.0.6",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "peerflix",
   "description": "Streaming torrent client for Node.js",
-  "version": "0.35.0 - iovis9 fork",
+  "version": "0.35.0",
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
-  "homepage": "https://github.com/iovis9/peerflix",
+  "homepage": "https://github.com/mafintosh/peerflix",
   "main": "index.js",
   "bugs": {
-    "url": "https://github.com/iovis9/peerflix/issues"
+    "url": "https://github.com/mafintosh/peerflix/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/iovis9/peerflix.git"
+    "url": "git://github.com/mafintosh/peerflix.git"
   },
   "bin": {
     "peerflix": "./app.js"


### PR DESCRIPTION
Fixes #274 When passed subtitles the vlc command was badly generated and it failed silently.
Someone should test that it still works on Windows as this was the origin of the failure.