### PR TITLE
Use airplayer

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,8 +102,6 @@ if (argv._.length > 1) {
   POTPLAYER_ARGS += ' ' + playerArgs
 }
 
-var noop = function () {}
-
 var ontorrent = function (torrent) {
   if (argv['peer-port']) argv.peerPort = Number(argv['peer-port'])
 
@@ -298,11 +296,11 @@ var ontorrent = function (torrent) {
       openUrl('https://85d514b3e548d934d8ff7c45a54732e65a3162fe.htmlb.in/#' + localHref)
     }
     if (argv.airplay) {
-      var browser = require('airplay-js').createBrowser()
-      browser.on('deviceOn', function (device) {
-        device.play(href, 0, noop)
+      var list = require('airplayer')()
+      list.once('update', function (player) {
+        list.destroy()
+        player.play(href)
       })
-      browser.start()
     }
 
     if (argv['on-listening']) proc.exec(argv['on-listening'] + ' ' + href)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "peerflix": "./app.js"
   },
   "dependencies": {
-    "airplay-js": "^0.2.5",
+    "airplayer": "^2.0.0",
     "clivas": "^0.1.4",
     "inquirer": "^0.8.0",
     "keypress": "^0.2.1",
@@ -38,7 +38,7 @@
     "standard": "^2.2.3"
   },
   "optionalDependencies": {
-    "airplay-js": "^0.2.5"
+    "airplayer": "^2.0.0"
   },
   "scripts": {
     "test": "standard"


### PR DESCRIPTION
This PR uses the [airplayer](https://github.com/watson/airplayer) module instead of [airplay-js](https://github.com/guerrerocarlos/node-airplay-js).

As far as I can see, the main feature differences between the two modules are:

- airplay-js serves the video using HLS, airplayer just streams the video using HTTPS range requests
- airplay-js supports using ffmpeg (if present on the system) to transpile and cut up the video into smaller pieces to be served as an HLS playlist. Airplayer does not use ffmpeg, so does not support transpiling, but will therefore use significant less CPU for videos that does not need to be transpiled
- airplay-js supports subtitles if ffmpeg is used
- airplayer does not write anything to stdout or stderr

Thoughts?