### PR TITLE
Fix: VLC Playback Blank Entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ if (!filename) {
   process.exit(1)
 }
 
-var VLC_ARGS = '-q ' + (onTop ? '--video-on-top' : '') + ' --play-and-exit'
+var VLC_ARGS = '-q' + (onTop ? ' --video-on-top' : '') + ' --play-and-exit'
 var OMX_EXEC = argv.jack ? 'omxplayer -r -o local ' : 'omxplayer -r -o hdmi '
 var MPLAYER_EXEC = 'mplayer ' + (onTop ? '-ontop' : '') + ' -really-quiet -noidx -loop 0 '
 var SMPLAYER_EXEC = 'smplayer ' + (onTop ? '-ontop' : '')


### PR DESCRIPTION
**Fixed**: VLC Playlist has a Blank Entry, which vlc interprets as '*play working directory*',

This causes vlc to attempt and playback every single file (.dll \ .exe, etc..) in the directory, 

The final result is a playlist complete of weird annoying sounds.

**The entry looks like this:**
![](https://i.imgur.com/XYgWBEG.png)

**After playback of 1st 'track' is complete, the entry turns into:**
![](https://i.imgur.com/xaXIbnt.png)



Fixed by modifying white space location for the vlc arguments.