### PR TITLE
add support for torrent files

### DIFF
--- a/app.js
+++ b/app.js
@@ -458,10 +458,26 @@ var ontorrent = function (torrent) {
   }
 }
 
-parsetorrent.remote(filename, function (err, parsedtorrent) {
-  if (err) {
-    console.error(err.message)
-    process.exit(1)
-  }
-  ontorrent(parsedtorrent)
-})
+if(filename.match("^magnet:")) {
+  parsetorrent.remote(filename, function (err, parsedtorrent) {
+    if (err) {
+      console.error(err.message)
+      process.exit(1)
+    }
+    ontorrent(parsedtorrent)
+  })
+} else {
+  require('read-torrent')(filename, {headers: {
+      'User-Agent': 'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
+      'Accept-Language' :"fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3",
+      'Accept-Encoding' :"gzip, deflate, br",
+      'Accept' :"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    }
+  }, function(err, torrent) {
+      if (err) {
+        console.error(err)
+        process.exit(1)
+      }
+      ontorrent(torrent)
+  });
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pump": "^1.0.1",
     "range-parser": "^1.0.0",
     "rc": "^1.1.6",
+    "read-torrent": "^1.3.0",
     "torrent-stream": "^1.0.1",
     "windows-no-runnable": "0.0.6",
     "xtend": "^4.0.0"


### PR DESCRIPTION
Hi,

not sure this is all correct i quickly wrote that to be able to fetch torrent from url / files,

```
node  app.js "http://....file.torrent"
node  app.js "~/dld/.torrent"
```

unsure why https://github.com/feross/parse-torrent won t parse those uri directly :s but read torrent works!

Also i still have troubles with websites fronted by cloudflare, it returns 503. I could not find a way to bypass this.