### PR TITLE
passes filename as title to vlc

### DIFF
--- a/app.js
+++ b/app.js
@@ -192,6 +192,8 @@ var ontorrent = function (torrent) {
     var timePaused = 0
     var pausedAt = null
 
+    VLC_ARGS += ' --meta-title="' + filename.replace(/"/g, '\\"') + '"'
+
     if (argv.all) {
       filename = engine.torrent.name
       filelength = engine.torrent.length


### PR DESCRIPTION
adds usage of `--meta-title` to VLC's args (addressing #225, and #244)

**Note:** this requires vlsub 0.10+