### PR TITLE
Sort files by filename when using --list

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,6 +152,7 @@ var ontorrent = function (torrent) {
 
     var onready = function () {
       if (interactive) {
+        var filenamesInOriginalOrder = engine.files.map(file => file.path)
         inquirer.prompt([{
           type: 'list',
           name: 'file',
@@ -161,7 +162,7 @@ var ontorrent = function (torrent) {
             .map(function (file, i) {
               return {
                 name: file.name + ' : ' + bytes(file.length),
-                value: engine.files.map(file=>file.path).indexOf(file.path)
+                value: filenamesInOriginalOrder.indexOf(file.path)
               }
             })
         }]).then(function (answers) {

--- a/app.js
+++ b/app.js
@@ -156,12 +156,14 @@ var ontorrent = function (torrent) {
           type: 'list',
           name: 'file',
           message: 'Choose one file',
-          choices: engine.files.map(function (file, i) {
-            return {
-              name: file.name + ' : ' + bytes(file.length),
-              value: i
-            }
-          })
+          choices: engine.files
+            .sort((file1, file2) => file1.name > file2.name ? 1 : -1)
+            .map(function (file, i) {
+              return {
+                name: file.name + ' : ' + bytes(file.length),
+                value: i
+              }
+            })
         }]).then(function (answers) {
           argv.index = answers.file
           delete argv.list

--- a/app.js
+++ b/app.js
@@ -156,12 +156,12 @@ var ontorrent = function (torrent) {
           type: 'list',
           name: 'file',
           message: 'Choose one file',
-          choices: engine.files
-            .sort((file1, file2) => file1.name > file2.name ? 1 : -1)
+          choices: Array.from(engine.files)
+            .sort((file1, file2) => file1.path.localeCompare(file2.path))
             .map(function (file, i) {
               return {
                 name: file.name + ' : ' + bytes(file.length),
-                value: i
+                value: engine.files.map(file=>file.path).indexOf(file.path)
               }
             })
         }]).then(function (answers) {


### PR DESCRIPTION
When a torrent has many files, the appear in what seems to be random order when using the --list option. This small change makes it so files are sorted by filename.