### PR TITLE
Fix unresponsive keyboard input when is used with an -l flag

### DIFF
--- a/app.js
+++ b/app.js
@@ -387,6 +387,7 @@ var ontorrent = function (torrent) {
         draw()
       })
       process.stdin.setRawMode(true)
+      process.stdin.resume()
     }
 
     var draw = function () {


### PR DESCRIPTION
We need to call `process.stdin.resume()` somewhere down the line,
after having used Inquirer (maybe it's one of its deps who calls
`process.stdin.pause()`) to start responding to keyboard presses again.
The fix was tested on MacOS 10.14 and NodeJS v8.9.4.

Closes #321