### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:10-jessie-slim
+
+COPY index.js /app/index.js
+COPY app.js /app/app.js
+COPY package.json /app/package.json
+
+WORKDIR /app
+RUN npm install
+EXPOSE 8888
+ENTRYPOINT ["node", "app.js"]


### PR DESCRIPTION
This PR provides peerflix with a simple Dockerfile to use the project without having to install nodes or npm.

Build with `docker build -t peerflix`
Then run with `docker run -it --rm peerflix` using the same arguments that you would you use with peerflix and without forgetting to expose the streaming port, for example with `-p 8888:8888`